### PR TITLE
Switch to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: voila-gallery-render-stl
+channels:
+- conda-forge
+dependencies:
+- ipyvolume=0.5.2
+- ipywidgets=7.5.0
+- numpy-stl=2.10.1
+- voila=0.1.6
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-ipyvolume==0.5.2
-ipywidgets==7.5.0
-numpy-stl==2.10.1
-voila==0.1.6


### PR DESCRIPTION
Switch to conda's environment.yml to specify the dependencies.

This seems to install the correct version of `Pygments` (2.4.2 at the time of writing) and should fix these 500 errors.

https://github.com/voila-gallery/gallery/issues/58 is still relevant though.