### PR TITLE
Unpin `voila`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,8 @@ name: voila-gallery-render-stl
 channels:
   - conda-forge
 dependencies:
-  - ipyvolume=0.5.2
-  - ipywidgets=7.5.0
-  - numpy-stl=2.10.1
-  - voila=0.1.20
+  - ipyvolume
+  - ipywidgets >=7.6.0,<8
+  - numpy-stl >=2.10.1,<3
+  - voila
   - voila-material


### PR DESCRIPTION
Update dependencies to unpin `voila`.

https://mybinder.org/v2/gh/voila-gallery/render-stl/update?urlpath=voila%2Frender%2Findex.ipynb